### PR TITLE
Added option to the data source to allow easy adjustment of start end times

### DIFF
--- a/webapp/src/main/java/web/org/perfmon4j/restdatasource/util/DateTimeHelper.java
+++ b/webapp/src/main/java/web/org/perfmon4j/restdatasource/util/DateTimeHelper.java
@@ -39,6 +39,8 @@ public class DateTimeHelper {
 	private static final Pattern DATE_TIME = Pattern.compile("(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2})");
 	
 	public DateTimeValue parseDateTime(String dateTime) {
+		// Trim of any time adjustment leftover on the incoming value
+		dateTime = TimeAdjustmentValue.stripTimeAdjustment(dateTime);
 		DateTimeValue result = null;
 		
 		// Ignore case on time matching...

--- a/webapp/src/main/java/web/org/perfmon4j/restdatasource/util/TimeAdjustmentValue.java
+++ b/webapp/src/main/java/web/org/perfmon4j/restdatasource/util/TimeAdjustmentValue.java
@@ -24,7 +24,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class TimeAdjustmentValue {
-	private static final Pattern PATTERN = Pattern.compile("\\{([\\-\\+]?\\d*)([HDWM]?)\\}");
+	private static final Pattern PATTERN = Pattern.compile("\\s*\\{([\\-\\+]?\\d*)([HDWM]?)\\}");
 	
 	public enum Period {
 		NOADJUSTMENT,
@@ -50,6 +50,17 @@ public class TimeAdjustmentValue {
 		return period;
 	}
 
+	static public String stripTimeAdjustment(String input) {
+		String result = input;
+		
+		if (input != null) {
+			Matcher m = PATTERN.matcher(input);
+			result = m.replaceFirst("");
+		}
+		
+		return result;
+	}
+	
 	static public TimeAdjustmentValue parse(String input) {
 		TimeAdjustmentValue result = null;
 		if (input != null) {

--- a/webapp/src/main/java/web/org/perfmon4j/restdatasource/util/TimeAdjustmentValue.java
+++ b/webapp/src/main/java/web/org/perfmon4j/restdatasource/util/TimeAdjustmentValue.java
@@ -1,0 +1,108 @@
+/*
+ *	Copyright 2017 Follett School Solutions 
+ *
+ *	This file is part of PerfMon4j(tm).
+ *
+ * 	Perfmon4j is free software: you can redistribute it and/or modify
+ * 	it under the terms of the GNU Lesser General Public License, version 3,
+ * 	as published by the Free Software Foundation.  This program is distributed
+ * 	WITHOUT ANY WARRANTY OF ANY KIND, WITHOUT AN IMPLIED WARRANTY OF MERCHANTIBILITY,
+ * 	OR FITNESS FOR A PARTICULAR PURPOSE.  You should have received a copy of the GNU Lesser General Public 
+ * 	License, Version 3, along with this program.  If not, you can obtain the LGPL v.s at 
+ * 	http://www.gnu.org/licenses/
+ * 	
+ * 	perfmon4j@fsc.follett.com
+ * 	David Deuchert
+ * 	Follett School Solutions
+ * 	1391 Corporate Drive
+ * 	McHenry, IL 60050
+ * 
+*/
+package web.org.perfmon4j.restdatasource.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TimeAdjustmentValue {
+	private static final Pattern PATTERN = Pattern.compile("\\{([\\-\\+]?\\d*)([HDWM]?)\\}");
+	
+	public enum Period {
+		NOADJUSTMENT,
+		HOUR,
+		DAY,
+		WEEK,
+		MONTH
+	}
+
+	private final int increment;
+	private final Period period;
+	
+	public TimeAdjustmentValue(Period period, int increment) {
+		this.increment = increment;
+		this.period = period;
+	}
+
+	public int getIncrement() {
+		return increment;
+	}
+
+	public Period getPeriod() {
+		return period;
+	}
+
+	static public TimeAdjustmentValue parse(String input) {
+		TimeAdjustmentValue result = null;
+		if (input != null) {
+			Matcher m = PATTERN.matcher(input);
+			if (m.find()) {
+				if (m.groupCount() > 0 && !"".equals(m.group(1))) {
+					Period p = Period.DAY; // Default value;
+					int i = Integer.parseInt(m.group(1));
+					String g2 = m.group(2);
+					if ("H".equals(g2)) {
+						p = Period.HOUR;
+					} else if ("W".equals(g2)) {
+						p = Period.WEEK;
+					} else if ("M".equals(g2)) {
+						p = Period.MONTH;
+					}
+					result = new TimeAdjustmentValue(p, i);
+				} else {
+					result = new TimeAdjustmentValue(Period.NOADJUSTMENT, 0);
+				}
+			}
+		}
+		return result;
+	}
+	
+	@Override
+	public String toString() {
+		return "TimeAdjustmentValue [increment=" + increment + ", period="
+				+ period + "]";
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + increment;
+		result = prime * result + ((period == null) ? 0 : period.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		TimeAdjustmentValue other = (TimeAdjustmentValue) obj;
+		if (increment != other.increment)
+			return false;
+		if (period != other.period)
+			return false;
+		return true;
+	}
+}

--- a/webapp/src/main/java/web/org/perfmon4j/restdatasource/util/TimeAdjustmentValue.java
+++ b/webapp/src/main/java/web/org/perfmon4j/restdatasource/util/TimeAdjustmentValue.java
@@ -20,6 +20,8 @@
 */
 package web.org.perfmon4j.restdatasource.util;
 
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -85,6 +87,36 @@ public class TimeAdjustmentValue {
 		}
 		return result;
 	}
+	
+
+	/**
+	 * 
+	 * @param value
+	 * @return - The input value modified to match the period and increment  
+	 */
+	public long adjustDateTime(long value) {
+		long result = value;
+		
+		if (!Period.NOADJUSTMENT.equals(period)) {
+			Calendar cal = new GregorianCalendar();
+			cal.setTimeInMillis(value);
+			
+			if (Period.HOUR.equals(period)) {
+				cal.add(Calendar.HOUR, increment);
+			} else if (Period.DAY.equals(period)) {
+				cal.add(Calendar.DATE, increment);
+			} else if (Period.WEEK.equals(period)) {
+				cal.add(Calendar.DATE, increment * 7);
+			} else if (Period.MONTH.equals(period)) {
+				cal.add(Calendar.MONTH, increment);
+			}
+			
+			result = cal.getTimeInMillis();
+		}
+		
+		return result;
+	}
+	
 	
 	@Override
 	public String toString() {

--- a/webapp/src/test/java/web/org/perfmon4j/restdatasource/DataSourceRestImplTest.java
+++ b/webapp/src/test/java/web/org/perfmon4j/restdatasource/DataSourceRestImplTest.java
@@ -24,6 +24,8 @@ package web.org.perfmon4j.restdatasource;
 
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -598,6 +600,53 @@ public class DataSourceRestImplTest extends TestCase {
 			tearDownDatabase();
 		}
 	}
+
+	public void testGetStartStop_AdjustStartOnly() {
+		String startTime = "2017-09-28T05:00";
+		String endTime   = "2017-09-28T06:00";   
+
+		Calendar expectedCalStart = new GregorianCalendar(2017, 8, 28, 4, 0); //2017-09-28T04:00
+		Calendar expectedCalEnd = new GregorianCalendar(2017, 8, 28, 5, 0, 59); //2017-09-28T05:00
+		expectedCalEnd.set(Calendar.MILLISECOND, 999);
+		
+		// Add the timeAdjustment only to the startTime.  It should apply to both start and end parameters.
+		long[] result = DataSourceRestImpl.getStartStopTime(startTime + "{-1H}", endTime);
+		
+		assertEquals("Start time should have been modified", expectedCalStart.getTimeInMillis(), result[0]);
+		assertEquals("End time should have been modified", expectedCalEnd.getTimeInMillis(), result[1]);
+	}
+	
+	public void testGetStartStop_AdjustEndOnly() {
+		String startTime = "2017-09-28T05:00";
+		String endTime   = "2017-09-28T06:00";   
+
+		Calendar expectedCalStart = new GregorianCalendar(2017, 8, 28, 4, 0); //2017-09-28T04:00
+		Calendar expectedCalEnd = new GregorianCalendar(2017, 8, 28, 5, 0, 59); //2017-09-28T05:00
+		expectedCalEnd.set(Calendar.MILLISECOND, 999);
+		
+		// Add the timeAdjustment only to the endTime.  It should apply to both start and end parameters.
+		long[] result = DataSourceRestImpl.getStartStopTime(startTime, endTime + "{-1H}");
+		
+		assertEquals("Start time should have been modified", expectedCalStart.getTimeInMillis(), result[0]);
+		assertEquals("End time should have been modified", expectedCalEnd.getTimeInMillis(), result[1]);
+	}
+
+	public void testGetStartStop_AdjustBothStartAndEnd() {
+		String startTime = "2017-09-28T05:00";
+		String endTime   = "2017-09-28T06:00";   
+
+		Calendar expectedCalStart = new GregorianCalendar(2017, 8, 28, 4, 0); //2017-09-28T04:00
+		Calendar expectedCalEnd = new GregorianCalendar(2017, 8, 28, 6, 0, 59); //2017-09-28T06:00
+		expectedCalEnd.set(Calendar.MILLISECOND, 999);
+		
+		// Move the start time back 1 hour, but leave the endtime the same by appending "{}" to the 
+		// end time.
+		long[] result = DataSourceRestImpl.getStartStopTime(startTime + "{-1H}", endTime + "{}");
+		
+		assertEquals("Start time should have been modified", expectedCalStart.getTimeInMillis(), result[0]);
+		assertEquals("End time should have been modified", expectedCalEnd.getTimeInMillis(), result[1]);
+	}
+	
 	
 	private MockHttpResponse queryThroughRest(String databaseID, String seriesDefinition) throws URISyntaxException {
 		return queryThroughRest(databaseID, seriesDefinition, "");

--- a/webapp/src/test/java/web/org/perfmon4j/restdatasource/util/DateTimeHelperTest.java
+++ b/webapp/src/test/java/web/org/perfmon4j/restdatasource/util/DateTimeHelperTest.java
@@ -24,8 +24,9 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
-import junit.framework.TestCase;
 import javax.ws.rs.BadRequestException;
+
+import junit.framework.TestCase;
 
 public class DateTimeHelperTest extends TestCase {
 	private final DateTimeHelper helper = new TestDateTimeHelper();
@@ -281,6 +282,14 @@ public class DateTimeHelperTest extends TestCase {
 		assertEquals(0, cal.get(Calendar.MILLISECOND));
 	}
 	
+
+	public void testParseDateTimeIgnoresTimeAdjustment() throws Exception {
+		try {
+			helper.parseDateTime("now {-1D}");
+		} catch (Exception e) {
+			fail("Should have ignored the time adjustment...This is handled in Rest Implementation layer");
+		}
+	}
 	
 	
 	

--- a/webapp/src/test/java/web/org/perfmon4j/restdatasource/util/TimeAdjustmentValueTest.java
+++ b/webapp/src/test/java/web/org/perfmon4j/restdatasource/util/TimeAdjustmentValueTest.java
@@ -148,4 +148,23 @@ public class TimeAdjustmentValueTest extends TestCase {
 		assertEquals("negative value", negative2, TimeAdjustmentValue.parse("{-2M}"));
 	}
 
+	
+	/**
+	 * 
+	 * @throws Exception
+	 */
+	public void testStripTimeAdjustments() throws Exception { 
+		String timeValue = "2017-09-27T15:30";
+		
+		assertEquals("Invalid adjustment \"{2X}\" should NOT be stripped", timeValue + " {2X}", TimeAdjustmentValue.stripTimeAdjustment(timeValue + " {2X}"));
+		
+		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + "{+2M}"));
+		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " {+2M}"));
+		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " {-2D}"));
+		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " {-2}"));
+		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " {+2}"));
+		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " {2}"));
+		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " {}"));
+	}
+	
 }

--- a/webapp/src/test/java/web/org/perfmon4j/restdatasource/util/TimeAdjustmentValueTest.java
+++ b/webapp/src/test/java/web/org/perfmon4j/restdatasource/util/TimeAdjustmentValueTest.java
@@ -20,6 +20,9 @@
 */
 package web.org.perfmon4j.restdatasource.util;
 
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
 import junit.framework.TestCase;
 import web.org.perfmon4j.restdatasource.util.TimeAdjustmentValue.Period;
 
@@ -167,4 +170,77 @@ public class TimeAdjustmentValueTest extends TestCase {
 		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " {}"));
 	}
 	
+	public void testAdjustNoAdjustment() throws Exception { 
+		TimeAdjustmentValue adjustment = new TimeAdjustmentValue(Period.NOADJUSTMENT, 10);
+		
+		long now = System.currentTimeMillis();
+		
+		assertEquals("Should be no adjustment", now, adjustment.adjustDateTime(now));
+	}
+
+	public void testAdjustHours() throws Exception { 
+		TimeAdjustmentValue adjustment = new TimeAdjustmentValue(Period.HOUR, -2);
+		
+		Calendar calStart = new GregorianCalendar(2017, 9, 10, 0, 0);
+		Calendar calAdjust = new GregorianCalendar(2017, 9, 9, 22, 0);
+		
+		assertEquals("Should be moved back 2 hours", calAdjust.getTimeInMillis(), adjustment.adjustDateTime(calStart.getTimeInMillis()));
+	}
+
+	public void testAdjustDays() throws Exception { 
+		TimeAdjustmentValue adjustment = new TimeAdjustmentValue(Period.DAY, -2);
+		
+		Calendar calStart = new GregorianCalendar(2017, 8, 1);
+		Calendar calAdjust = new GregorianCalendar(2017, 7, 30);
+		
+		assertEquals("Should be moved back 2 days", calAdjust.getTimeInMillis(), adjustment.adjustDateTime(calStart.getTimeInMillis()));
+	}
+
+	public void testAdjustDaysRollsOverYear() throws Exception { 
+		TimeAdjustmentValue adjustment = new TimeAdjustmentValue(Period.DAY, -2);
+		
+		Calendar calStart = new GregorianCalendar(2017, 0, 1);
+		Calendar calAdjust = new GregorianCalendar(2016, 11, 30);
+		
+		assertEquals("Should be moved back 2 days", calAdjust.getTimeInMillis(), adjustment.adjustDateTime(calStart.getTimeInMillis()));
+	}
+
+
+	public void testAdjustWeeks() throws Exception { 
+		TimeAdjustmentValue adjustment = new TimeAdjustmentValue(Period.WEEK, -2);
+		
+		Calendar calStart = new GregorianCalendar(2017, 8, 1);
+		Calendar calAdjust = new GregorianCalendar(2017, 7, 18);
+		
+		assertEquals("Should be moved back 2 weeks", calAdjust.getTimeInMillis(), adjustment.adjustDateTime(calStart.getTimeInMillis()));
+	}
+	
+	
+	public void testAdjustMonth() throws Exception { 
+		TimeAdjustmentValue adjustment = new TimeAdjustmentValue(Period.MONTH, -2);
+		
+		Calendar calStart = new GregorianCalendar(2017, 8, 1);
+		Calendar calAdjust = new GregorianCalendar(2017, 6, 1);
+		
+		assertEquals("Should be moved back 2 months", calAdjust.getTimeInMillis(), adjustment.adjustDateTime(calStart.getTimeInMillis()));
+	}
+
+	public void testAdjustMonthAcrossYear() throws Exception { 
+		TimeAdjustmentValue adjustment = new TimeAdjustmentValue(Period.MONTH, -2);
+		
+		Calendar calStart = new GregorianCalendar(2017, 1, 5);
+		Calendar calAdjust = new GregorianCalendar(2016, 11, 5);
+		
+		assertEquals("Should be moved back 2 months", calAdjust.getTimeInMillis(), adjustment.adjustDateTime(calStart.getTimeInMillis()));
+	}
+
+	public void testAdjustMonthIntoShorterMonth() throws Exception { 
+		TimeAdjustmentValue adjustment = new TimeAdjustmentValue(Period.MONTH, -1);
+		
+		Calendar calStart = new GregorianCalendar(2017, 2, 31);  // March 31
+		Calendar calAdjust = new GregorianCalendar(2017, 1, 28); // February 28th
+		
+		assertEquals("Should be moved back 1 month", calAdjust.getTimeInMillis(), adjustment.adjustDateTime(calStart.getTimeInMillis()));
+	}
+
 }

--- a/webapp/src/test/java/web/org/perfmon4j/restdatasource/util/TimeAdjustmentValueTest.java
+++ b/webapp/src/test/java/web/org/perfmon4j/restdatasource/util/TimeAdjustmentValueTest.java
@@ -1,0 +1,151 @@
+/*
+ *	Copyright 2017 Follett School Solutions 
+ *
+ *	This file is part of PerfMon4j(tm).
+ *
+ * 	Perfmon4j is free software: you can redistribute it and/or modify
+ * 	it under the terms of the GNU Lesser General Public License, version 3,
+ * 	as published by the Free Software Foundation.  This program is distributed
+ * 	WITHOUT ANY WARRANTY OF ANY KIND, WITHOUT AN IMPLIED WARRANTY OF MERCHANTIBILITY,
+ * 	OR FITNESS FOR A PARTICULAR PURPOSE.  You should have received a copy of the GNU Lesser General Public 
+ * 	License, Version 3, along with this program.  If not, you can obtain the LGPL v.s at 
+ * 	http://www.gnu.org/licenses/
+ * 	
+ * 	perfmon4j@fsc.follett.com
+ * 	David Deuchert
+ * 	Follett School Solutions
+ * 	1391 Corporate Drive
+ * 	McHenry, IL 60050
+ * 
+*/
+package web.org.perfmon4j.restdatasource.util;
+
+import junit.framework.TestCase;
+import web.org.perfmon4j.restdatasource.util.TimeAdjustmentValue.Period;
+
+public class TimeAdjustmentValueTest extends TestCase {
+	
+	public TimeAdjustmentValueTest(String name) {
+		super(name);
+	}
+
+	protected void setUp() throws Exception {
+		super.setUp();
+	}
+
+	protected void tearDown() throws Exception {
+		super.tearDown();
+	}
+
+	public void testNothingToParse() throws Exception { 
+		assertNull("There is nothing here", TimeAdjustmentValue.parse(null));
+		assertNull("There is nothing here", TimeAdjustmentValue.parse(""));
+		assertNull("There is nothing here", TimeAdjustmentValue.parse("asfasdf"));
+		assertNull("There is nothing here", TimeAdjustmentValue.parse("{asfasdf}"));
+		assertNull("There is nothing here", TimeAdjustmentValue.parse("{asfasdf"));
+		assertNull("There is nothing here", TimeAdjustmentValue.parse("{asfasdf}"));
+	}
+	
+	/**
+	 * An empty "{}" pattern indicate that no adjustment should be applied to the specific date field.
+	 * 
+	 * @throws Exception
+	 */
+	public void testParseNoOpAdjustment() throws Exception { 
+		TimeAdjustmentValue noAdjustment = new TimeAdjustmentValue(Period.NOADJUSTMENT, 0);
+		
+		assertEquals("No adjustment", noAdjustment, TimeAdjustmentValue.parse("{}"));
+		assertEquals("Date/Time value before is OK", noAdjustment, TimeAdjustmentValue.parse("now{}"));
+		assertEquals("Date/Time value before is OK with whitespace", noAdjustment, TimeAdjustmentValue.parse("now{}"));
+		assertEquals("Date/Time value after is OK", noAdjustment, TimeAdjustmentValue.parse("{}now"));
+		assertEquals("Date/Time value after is OK with whitespace", noAdjustment, TimeAdjustmentValue.parse("{} now"));
+	}
+	
+	/**
+	 * The default period will be Days.  The following values will result in adding 2 days to the 
+	 * specified time:
+	 * 	"2017-09-27T15:30 {2}"
+	 * 	"2017-09-27T15:30 {2D}"
+	 * 	"2017-09-27T15:30 {+2}"
+	 * 	"2017-09-27T15:30 {+2D}"
+	 * 
+	 * The following values will result in subtracting 2 days from the specified time:
+	 * 	"2017-09-27T15:30 {-2}"
+	 * 	"2017-09-27T15:30 {-2D}"
+	 * 
+	 * @throws Exception
+	 */
+	public void testParseDays() throws Exception { 
+		TimeAdjustmentValue positive2Days = new TimeAdjustmentValue(Period.DAY, 2);
+		TimeAdjustmentValue negative2Days = new TimeAdjustmentValue(Period.DAY, -2);
+		
+		assertEquals("+sign allowed, period defaults to days", positive2Days, TimeAdjustmentValue.parse("{+2}"));
+		assertEquals("period defaults to days", positive2Days, TimeAdjustmentValue.parse("{2}"));
+		assertEquals("explicit period", positive2Days, TimeAdjustmentValue.parse("{2D}"));
+		assertEquals("period defaults to days", negative2Days, TimeAdjustmentValue.parse("{-2}"));
+		assertEquals("explicit period", negative2Days, TimeAdjustmentValue.parse("{-2D}"));
+	}
+	
+
+	/**
+	 * The following values will result in adding 2 hours to the 
+	 * specified time:
+	 * 	"2017-09-27T15:30 {2H}"
+	 * 	"2017-09-27T15:30 {+2H}"
+	 * 
+	 * The following values will result in subtracting 2 hours from the specified time:
+	 * 	"2017-09-27T15:30 {-2H}"
+	 * 
+	 * @throws Exception
+	 */
+	public void testParseHours() throws Exception { 
+		TimeAdjustmentValue positive2 = new TimeAdjustmentValue(Period.HOUR, 2);
+		TimeAdjustmentValue negative2 = new TimeAdjustmentValue(Period.HOUR, -2);
+		
+		assertEquals("+sign allowed", positive2, TimeAdjustmentValue.parse("{+2H}"));
+		assertEquals("+sign not required", positive2, TimeAdjustmentValue.parse("{2H}"));
+		assertEquals("negative value", negative2, TimeAdjustmentValue.parse("{-2H}"));
+	}
+
+	/**
+	 * The following values will result in adding 2 weeks to the 
+	 * specified time:
+	 * 	"2017-09-27T15:30 {2W}"
+	 * 	"2017-09-27T15:30 {+2W}"
+	 * 
+	 * The following values will result in subtracting 2 weeks from the specified time:
+	 * 	"2017-09-27T15:30 {-2W}"
+	 * 
+	 * @throws Exception
+	 */
+	public void testParseWeeks() throws Exception { 
+		TimeAdjustmentValue positive2 = new TimeAdjustmentValue(Period.WEEK, 2);
+		TimeAdjustmentValue negative2 = new TimeAdjustmentValue(Period.WEEK, -2);
+		
+		assertEquals("+sign allowed", positive2, TimeAdjustmentValue.parse("{+2W}"));
+		assertEquals("+sign not required", positive2, TimeAdjustmentValue.parse("{2W}"));
+		assertEquals("negative value", negative2, TimeAdjustmentValue.parse("{-2W}"));
+	}
+
+
+	/**
+	 * The following values will result in adding 2 months to the 
+	 * specified time:
+	 * 	"2017-09-27T15:30 {2M}"
+	 * 	"2017-09-27T15:30 {+2M}"
+	 * 
+	 * The following values will result in subtracting 2 months from the specified time:
+	 * 	"2017-09-27T15:30 {-2M}"
+	 * 
+	 * @throws Exception
+	 */
+	public void testParseMonths() throws Exception { 
+		TimeAdjustmentValue positive2 = new TimeAdjustmentValue(Period.MONTH, 2);
+		TimeAdjustmentValue negative2 = new TimeAdjustmentValue(Period.MONTH, -2);
+		
+		assertEquals("+sign allowed", positive2, TimeAdjustmentValue.parse("{+2M}"));
+		assertEquals("+sign not required", positive2, TimeAdjustmentValue.parse("{2M}"));
+		assertEquals("negative value", negative2, TimeAdjustmentValue.parse("{-2M}"));
+	}
+
+}


### PR DESCRIPTION
For example, if I have a chart this is configured to run for each day between 8:00 am and 3:30 pm I would have the following start/end times defined in the chart
   Start: 8:00
   End:  15:30

With this enhancement if I wanted to see the same data for the previous day all I would need to do is change the parameters to be:
  Start: 8:00 {-1D}
  End: 15:30

If I wanted to see if from the same day last week I could change it to:
  Start: 8:00 {-1W}
  End: 15:30