### PR TITLE
Changes time adjustment to URL safe characters

### DIFF
--- a/webapp/src/main/java/web/org/perfmon4j/restdatasource/util/TimeAdjustmentValue.java
+++ b/webapp/src/main/java/web/org/perfmon4j/restdatasource/util/TimeAdjustmentValue.java
@@ -26,7 +26,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class TimeAdjustmentValue {
-	private static final Pattern PATTERN = Pattern.compile("\\s*\\{([\\-\\+]?\\d*)([HDWM]?)\\}");
+	private static final Pattern PATTERN = Pattern.compile("\\s*\\~ADJ([\\-\\+]?\\d*)([HDWM]?)");
 	
 	public enum Period {
 		NOADJUSTMENT,

--- a/webapp/src/test/java/web/org/perfmon4j/restdatasource/DataSourceRestImplTest.java
+++ b/webapp/src/test/java/web/org/perfmon4j/restdatasource/DataSourceRestImplTest.java
@@ -610,7 +610,7 @@ public class DataSourceRestImplTest extends TestCase {
 		expectedCalEnd.set(Calendar.MILLISECOND, 999);
 		
 		// Add the timeAdjustment only to the startTime.  It should apply to both start and end parameters.
-		long[] result = DataSourceRestImpl.getStartStopTime(startTime + "{-1H}", endTime);
+		long[] result = DataSourceRestImpl.getStartStopTime(startTime + "~ADJ-1H", endTime);
 		
 		assertEquals("Start time should have been modified", expectedCalStart.getTimeInMillis(), result[0]);
 		assertEquals("End time should have been modified", expectedCalEnd.getTimeInMillis(), result[1]);
@@ -625,7 +625,7 @@ public class DataSourceRestImplTest extends TestCase {
 		expectedCalEnd.set(Calendar.MILLISECOND, 999);
 		
 		// Add the timeAdjustment only to the endTime.  It should apply to both start and end parameters.
-		long[] result = DataSourceRestImpl.getStartStopTime(startTime, endTime + "{-1H}");
+		long[] result = DataSourceRestImpl.getStartStopTime(startTime, endTime + "~ADJ-1H");
 		
 		assertEquals("Start time should have been modified", expectedCalStart.getTimeInMillis(), result[0]);
 		assertEquals("End time should have been modified", expectedCalEnd.getTimeInMillis(), result[1]);
@@ -641,7 +641,7 @@ public class DataSourceRestImplTest extends TestCase {
 		
 		// Move the start time back 1 hour, but leave the endtime the same by appending "{}" to the 
 		// end time.
-		long[] result = DataSourceRestImpl.getStartStopTime(startTime + "{-1H}", endTime + "{}");
+		long[] result = DataSourceRestImpl.getStartStopTime(startTime + "~ADJ-1H", endTime + "~ADJ");
 		
 		assertEquals("Start time should have been modified", expectedCalStart.getTimeInMillis(), result[0]);
 		assertEquals("End time should have been modified", expectedCalEnd.getTimeInMillis(), result[1]);

--- a/webapp/src/test/java/web/org/perfmon4j/restdatasource/util/DateTimeHelperTest.java
+++ b/webapp/src/test/java/web/org/perfmon4j/restdatasource/util/DateTimeHelperTest.java
@@ -285,7 +285,7 @@ public class DateTimeHelperTest extends TestCase {
 
 	public void testParseDateTimeIgnoresTimeAdjustment() throws Exception {
 		try {
-			helper.parseDateTime("now {-1D}");
+			helper.parseDateTime("now ~ADJ-1D");
 		} catch (Exception e) {
 			fail("Should have ignored the time adjustment...This is handled in Rest Implementation layer");
 		}

--- a/webapp/src/test/java/web/org/perfmon4j/restdatasource/util/TimeAdjustmentValueTest.java
+++ b/webapp/src/test/java/web/org/perfmon4j/restdatasource/util/TimeAdjustmentValueTest.java
@@ -57,11 +57,11 @@ public class TimeAdjustmentValueTest extends TestCase {
 	public void testParseNoOpAdjustment() throws Exception { 
 		TimeAdjustmentValue noAdjustment = new TimeAdjustmentValue(Period.NOADJUSTMENT, 0);
 		
-		assertEquals("No adjustment", noAdjustment, TimeAdjustmentValue.parse("{}"));
-		assertEquals("Date/Time value before is OK", noAdjustment, TimeAdjustmentValue.parse("now{}"));
-		assertEquals("Date/Time value before is OK with whitespace", noAdjustment, TimeAdjustmentValue.parse("now{}"));
-		assertEquals("Date/Time value after is OK", noAdjustment, TimeAdjustmentValue.parse("{}now"));
-		assertEquals("Date/Time value after is OK with whitespace", noAdjustment, TimeAdjustmentValue.parse("{} now"));
+		assertEquals("No adjustment", noAdjustment, TimeAdjustmentValue.parse("~ADJ"));
+		assertEquals("Date/Time value before is OK", noAdjustment, TimeAdjustmentValue.parse("now~ADJ"));
+		assertEquals("Date/Time value before is OK with whitespace", noAdjustment, TimeAdjustmentValue.parse("now~ADJ"));
+		assertEquals("Date/Time value after is OK", noAdjustment, TimeAdjustmentValue.parse("~ADJnow"));
+		assertEquals("Date/Time value after is OK with whitespace", noAdjustment, TimeAdjustmentValue.parse(" ~ADJ"));
 	}
 	
 	/**
@@ -82,11 +82,11 @@ public class TimeAdjustmentValueTest extends TestCase {
 		TimeAdjustmentValue positive2Days = new TimeAdjustmentValue(Period.DAY, 2);
 		TimeAdjustmentValue negative2Days = new TimeAdjustmentValue(Period.DAY, -2);
 		
-		assertEquals("+sign allowed, period defaults to days", positive2Days, TimeAdjustmentValue.parse("{+2}"));
-		assertEquals("period defaults to days", positive2Days, TimeAdjustmentValue.parse("{2}"));
-		assertEquals("explicit period", positive2Days, TimeAdjustmentValue.parse("{2D}"));
-		assertEquals("period defaults to days", negative2Days, TimeAdjustmentValue.parse("{-2}"));
-		assertEquals("explicit period", negative2Days, TimeAdjustmentValue.parse("{-2D}"));
+		assertEquals("+sign allowed, period defaults to days", positive2Days, TimeAdjustmentValue.parse("~ADJ+2"));
+		assertEquals("period defaults to days", positive2Days, TimeAdjustmentValue.parse("~ADJ2"));
+		assertEquals("explicit period", positive2Days, TimeAdjustmentValue.parse("~ADJ2D"));
+		assertEquals("period defaults to days", negative2Days, TimeAdjustmentValue.parse("~ADJ-2"));
+		assertEquals("explicit period", negative2Days, TimeAdjustmentValue.parse("~ADJ-2D"));
 	}
 	
 
@@ -105,9 +105,9 @@ public class TimeAdjustmentValueTest extends TestCase {
 		TimeAdjustmentValue positive2 = new TimeAdjustmentValue(Period.HOUR, 2);
 		TimeAdjustmentValue negative2 = new TimeAdjustmentValue(Period.HOUR, -2);
 		
-		assertEquals("+sign allowed", positive2, TimeAdjustmentValue.parse("{+2H}"));
-		assertEquals("+sign not required", positive2, TimeAdjustmentValue.parse("{2H}"));
-		assertEquals("negative value", negative2, TimeAdjustmentValue.parse("{-2H}"));
+		assertEquals("+sign allowed", positive2, TimeAdjustmentValue.parse("~ADJ+2H"));
+		assertEquals("+sign not required", positive2, TimeAdjustmentValue.parse("~ADJ2H"));
+		assertEquals("negative value", negative2, TimeAdjustmentValue.parse("~ADJ-2H"));
 	}
 
 	/**
@@ -125,9 +125,9 @@ public class TimeAdjustmentValueTest extends TestCase {
 		TimeAdjustmentValue positive2 = new TimeAdjustmentValue(Period.WEEK, 2);
 		TimeAdjustmentValue negative2 = new TimeAdjustmentValue(Period.WEEK, -2);
 		
-		assertEquals("+sign allowed", positive2, TimeAdjustmentValue.parse("{+2W}"));
-		assertEquals("+sign not required", positive2, TimeAdjustmentValue.parse("{2W}"));
-		assertEquals("negative value", negative2, TimeAdjustmentValue.parse("{-2W}"));
+		assertEquals("+sign allowed", positive2, TimeAdjustmentValue.parse("~ADJ+2W"));
+		assertEquals("+sign not required", positive2, TimeAdjustmentValue.parse("~ADJ2W"));
+		assertEquals("negative value", negative2, TimeAdjustmentValue.parse("~ADJ-2W"));
 	}
 
 
@@ -146,9 +146,9 @@ public class TimeAdjustmentValueTest extends TestCase {
 		TimeAdjustmentValue positive2 = new TimeAdjustmentValue(Period.MONTH, 2);
 		TimeAdjustmentValue negative2 = new TimeAdjustmentValue(Period.MONTH, -2);
 		
-		assertEquals("+sign allowed", positive2, TimeAdjustmentValue.parse("{+2M}"));
-		assertEquals("+sign not required", positive2, TimeAdjustmentValue.parse("{2M}"));
-		assertEquals("negative value", negative2, TimeAdjustmentValue.parse("{-2M}"));
+		assertEquals("+sign allowed", positive2, TimeAdjustmentValue.parse("~ADJ+2M"));
+		assertEquals("+sign not required", positive2, TimeAdjustmentValue.parse("~ADJ2M"));
+		assertEquals("negative value", negative2, TimeAdjustmentValue.parse("~ADJ-2M"));
 	}
 
 	
@@ -161,13 +161,13 @@ public class TimeAdjustmentValueTest extends TestCase {
 		
 		assertEquals("Invalid adjustment \"{2X}\" should NOT be stripped", timeValue + " {2X}", TimeAdjustmentValue.stripTimeAdjustment(timeValue + " {2X}"));
 		
-		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + "{+2M}"));
-		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " {+2M}"));
-		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " {-2D}"));
-		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " {-2}"));
-		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " {+2}"));
-		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " {2}"));
-		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " {}"));
+		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + "~ADJ+2M"));
+		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " ~ADJ+2M"));
+		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " ~ADJ-2D"));
+		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " ~ADJ-2"));
+		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " ~ADJ+2"));
+		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " ~ADJ2"));
+		assertEquals("Valid adjustment should be stripped", timeValue, TimeAdjustmentValue.stripTimeAdjustment(timeValue + " ~ADJ"));
 	}
 	
 	public void testAdjustNoAdjustment() throws Exception { 


### PR DESCRIPTION
Now to adjust the time we no longer support the braces "{}".

Instead you append ~ADJ

For example to adjust the time 24 hours earlier you would use:
   ~ADJ+24H